### PR TITLE
Add zipmoney class to payment-method container

### DIFF
--- a/view/frontend/web/template/payment/zipmoney.html
+++ b/view/frontend/web/template/payment/zipmoney.html
@@ -1,4 +1,4 @@
-<div class="payment-method" data-bind="css: {'_active': (getCode() == isChecked())}">
+<div class="payment-method zipmoney" data-bind="css: {'_active': (getCode() == isChecked())}">
     <div class="payment-method-title field choice">
         <input type="radio"
                name="payment[method]"


### PR DESCRIPTION
This will allow the ZipMoney payment method list item to be targeted directly by either CSS or JS