### PR TITLE
Update Payload.php to fix issue

### DIFF
--- a/Helper/Payload.php
+++ b/Helper/Payload.php
@@ -513,13 +513,15 @@ class Payload extends  AbstractHelper
         $orderItem->setName($item->getName())
                   ->setAmount($item->getPriceInclTax() ? (float)$item->getPriceInclTax() : 0.00)
                   ->setReference((string)$item->getId())
-                  ->setDescription($description)
                   ->setQuantity(round($qty))
                   ->setType("sku")
                   ->setImageUri($this->_getProductImage($item))
                   ->setItemUri($item->getProduct()->getProductUrl())
                   ->setProductCode($item->getSku());  
         $itemsArray[] = $orderItem;
+        if(!empty($description)){
+            $orderItem->setDescription($description);
+        }
     }
 
     $this->_logger->debug($this->_helper->__("Shipping Required:- %s", !$this->_isVirtual ? "Yes" : "No"));


### PR DESCRIPTION
Fix can't checkout a product that has no short_description.
In M2. we don't need to enter product shore_description so please remove this attribute in case it is not set to make sure it doesn't throw an exception when the customer try to checkout
