### PR TITLE
Fix checkout when Terms & Conditions are enabled on checkout

### DIFF
--- a/view/frontend/web/js/action/set-payment-method.js
+++ b/view/frontend/web/js/action/set-payment-method.js
@@ -4,57 +4,14 @@
  */
 define(
     [
-        'jquery',
         'Magento_Checkout/js/model/quote',
-        'Magento_Checkout/js/model/url-builder',
-        'mage/storage',
-        'Magento_Checkout/js/model/error-processor',
-        'Magento_Customer/js/model/customer',
-        'Magento_Checkout/js/model/full-screen-loader'
-    ],
-    function ($, quote, urlBuilder, storage, errorProcessor, customer, fullScreenLoader) {
+        'Magento_Checkout/js/action/set-payment-information'
+    ], function (quote, setPaymentInformation) {
+
         'use strict';
 
         return function (messageContainer) {
-            var serviceUrl,
-                payload,
-                method = 'post',
-                paymentData = quote.paymentMethod();
-
-            /**
-             * Checkout for guest and registered customer.
-             */
-            if (!customer.isLoggedIn()) {
-                serviceUrl = urlBuilder.createUrl('/guest-carts/:cartId/set-payment-information', {
-                    cartId: quote.getQuoteId()
-                });
-                payload = {
-                    cartId: quote.getQuoteId(),
-                    email: quote.guestEmail,
-                    paymentMethod: paymentData,
-                    billingAddress: quote.billingAddress()
-                };
-                //method = 'post';
-            } else {
-                serviceUrl = urlBuilder.createUrl('/carts/mine/set-payment-information', {});
-                payload = {
-                    cartId: quote.getQuoteId(),
-                    //method: paymentData,                    
-                    paymentMethod: paymentData,
-                    billingAddress: quote.billingAddress()
-                };
-            }
-            
-            fullScreenLoader.startLoader();
-
-            return storage[method](
-                serviceUrl, JSON.stringify(payload)
-            ).fail(
-                function (response) {
-                    errorProcessor.process(response, messageContainer);
-                    fullScreenLoader.stopLoader();
-                }
-            );
+          return setPaymentInformation(messageContainer, quote.paymentMethod());
         };
     }
 );


### PR DESCRIPTION
Resolves #32 

Magento 2.2.4 was just released which introduced a new mixin (set-payment-information). Using this mixin to set the payment method resolves this issue.

This is the same approach as used in the PayPal Express checkout method in core.

**Note**: This fix will only work on 2.2.4+