### PR TITLE
Setting the etc/adminhtml/system.xml merchant keys type

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -26,11 +26,11 @@
                 <field id="title" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Title</label>                        
                 </field>
-                <field id="merchant_private_key" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="merchant_private_key" translate="label" type="password" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Private Key</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field> 
-                <field id="merchant_public_key" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="0">
+                <field id="merchant_public_key" translate="label" type="password" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="0">
                     <label>Public Key</label>                    
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>


### PR DESCRIPTION
Noticed that the public and private keys are visible as plain text in the admin panel when configuring the zipmoney API connection. Having multiple users logging in with different levels of access to information means it would be much better to have the key fields as password fields.

Please explain if this isn't able to be merged.

Thanks